### PR TITLE
Fix UI scaling issues

### DIFF
--- a/KerbalAlarmClock/AlarmObjects.cs
+++ b/KerbalAlarmClock/AlarmObjects.cs
@@ -418,7 +418,7 @@ namespace KerbalAlarmClock
         public Boolean EditWindowOpen = false;
         public Int32 AlarmLineWidth = 0;
         public Int32 AlarmLineHeight = 0;
-        public Int32 AlarmLineHeightExtra { get { return (AlarmLineHeight > 22*GameSettings.UI_SCALE) ? AlarmLineHeight - 22 : 0; } }
+        public Int32 AlarmLineHeightExtra { get { return (AlarmLineHeight > 22) ? AlarmLineHeight - 22 : 0; } }
 
 
         public override void OnEncodeToConfigNode()

--- a/KerbalAlarmClock/KerbalAlarmClock.csproj
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj
@@ -34,7 +34,7 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/KerbalAlarmClock/KerbalAlarmClock_Window.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_Window.cs
@@ -449,7 +449,7 @@ namespace KerbalAlarmClock
         internal void DrawWindows()
         {
             var size = GUI.skin.label.CalcSize(new GUIContent("X"));
-            intMainWindowAlarmListItemHeight = Mathf.RoundToInt(size.y) + Mathf.RoundToInt( (GUI.skin.label.padding.top + GUI.skin.label.padding.bottom) * GameSettings.UI_SCALE);
+            intMainWindowAlarmListItemHeight = Mathf.RoundToInt(size.y) + Mathf.RoundToInt( (GUI.skin.label.padding.top + GUI.skin.label.padding.bottom));
             //Debug.Log("[KerbalAlarmClock] a: " + size.ToString() + ", intMainWindowAlarmListItemHeight: " + intMainWindowAlarmListItemHeight);
 #if DEBUG
             if (_ShowDebugPane)

--- a/KerbalAlarmClock/KerbalAlarmClock_Window.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_Window.cs
@@ -480,8 +480,8 @@ namespace KerbalAlarmClock
                             ((alarmsDisplayed.Count-1) * intMainWindowAlarmListItemHeight) +
                             alarmsDisplayed.Sum(x => x.AlarmLineHeightExtra);
 
-Debug.Log("[KerbalAlarmClock] a: " + size.ToString() + ", intMainWindowAlarmListItemHeight: " + intMainWindowAlarmListItemHeight +
-    ", MainWindowPos.height: " + MainWindowPos.height);
+                        //Debug.Log("[KerbalAlarmClock] a: " + size.ToString() + ", intMainWindowAlarmListItemHeight: " + intMainWindowAlarmListItemHeight +
+                        //    ", MainWindowPos.height: " + MainWindowPos.height);
 
                     }
                     else

--- a/KerbalAlarmClock/Resources.cs
+++ b/KerbalAlarmClock/Resources.cs
@@ -690,7 +690,7 @@ namespace KerbalAlarmClock
         private static void SetStyleDefaults(Int32 FontSize=12)
         {
             Color32 colLabelText = new Color32(220, 220, 220, 255);
-            intFontSizeDefault = Mathf.RoundToInt( FontSize * GameSettings.UI_SCALE);
+            intFontSizeDefault = Mathf.RoundToInt(FontSize);
 
             //Common starting points
             styleDefLabel = new GUIStyle(CurrentSkin.label);


### PR DESCRIPTION
Resolve https://github.com/linuxgurugamer/KerbalAlarmClock/issues/6

Revert all of the GameSettings.UI_SCALE changes that LGG made when adopting the mod, since they seemed to have caused issues. This does not remove all mentions of GameSettings.UI_SCALE, as there were still some present from the original TriggerAu code.

My 1440p screen:
130%
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/142353fe-cc40-48a3-b381-f47c1dde5baa" />

100%
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/8f84ca0d-2a0b-4c6d-b873-0c9a3bc37d2c" />

80%
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/3b3965d6-ed8e-4a03-b378-d1c57b70b8d7" />


1080p (still on my 1440p monitor but scaled down via the main menu settings):
100%
<img width="1918" height="1082" alt="image" src="https://github.com/user-attachments/assets/8469db4d-97f6-4ebb-b34b-b06b4e43e5e6" />

130%
<img width="1913" height="1080" alt="image" src="https://github.com/user-attachments/assets/e449fe9f-0a3b-4fa1-a550-af1a6ad8e164" />

80%
<img width="1922" height="1083" alt="image" src="https://github.com/user-attachments/assets/6992056f-9fe5-4ce5-865b-41251888a133" />
