### PR TITLE
Remove coroutines, implement better fix for NRE

### DIFF
--- a/KerbalAlarmClock/API.cs
+++ b/KerbalAlarmClock/API.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Linq;
-using UnityEngine;
 
 namespace KerbalAlarmClock
 {
@@ -17,8 +15,6 @@ namespace KerbalAlarmClock
         /// </summary>
         public static KerbalAlarmClock APIInstance;
         public static Boolean APIReady = false;
-        private static KACAlarm alarmToDelete;
-        private static KACAlarm alarmToAdd;
 
         //Init the API Hooks
         private void APIAwake()
@@ -90,8 +86,7 @@ namespace KerbalAlarmClock
             tmpAlarm.TypeOfAlarm=AlarmType;
             tmpAlarm.Name=Name;
 
-            alarmToAdd = tmpAlarm;
-            StartCoroutine(CreateAlarm());
+            alarms.Add(tmpAlarm);
 
             return tmpAlarm.ID;
         }
@@ -110,8 +105,7 @@ namespace KerbalAlarmClock
                 if (tmpAlarm != null)
                 {
                     LogFormatted("API-DeleteAlarm-Deleting:{0}", AlarmID);
-                    alarmToDelete = tmpAlarm;
-                    StartCoroutine(DeleteAlarm());
+                    alarms.Remove(tmpAlarm);
                     blnReturn = true;
                 }
                 else
@@ -131,26 +125,6 @@ namespace KerbalAlarmClock
             KACAlarm.AlarmActionEnum actionChoice = (KACAlarm.AlarmActionEnum)Choice;
             DrawAlarmActionChoice3(ref actionChoice, LabelText, LabelWidth, ButtonWidth);
             return (Int32)actionChoice;
-        }
-
-        private IEnumerator CreateAlarm()
-        {
-            yield return new WaitForEndOfFrame();
-
-            if (alarms.FirstOrDefault(a => a.ID == alarmToAdd.ID) == null) // to ensure the api user did not try to make the same alarm while this was waiting
-            {
-                alarms.Add(alarmToAdd);
-            }
-        }
-
-        private IEnumerator DeleteAlarm()
-        {
-            yield return new WaitForEndOfFrame();
-
-            if (alarms.FirstOrDefault(a => a.ID == alarmToDelete.ID) != null) // to ensure the api user did not try to delete the same alarm while this was waiting
-            {
-                alarms.Remove(alarmToDelete);
-            }
         }
 
         //public Double DrawTimeEntryAPI(ref Double time, Int32 Prec, String LabelText, Int32 LabelWidth)

--- a/KerbalAlarmClock/KerbalAlarmClock_WindowAlarm.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowAlarm.cs
@@ -94,9 +94,11 @@ namespace KerbalAlarmClock
 
 		internal void FillAlarmWindow(int windowID)
 		{
-			KACAlarm tmpAlarm = alarms.GetByWindowID(windowID);
+            KACAlarm tmpAlarm = alarms.GetByWindowID(windowID);
 
-			GUILayout.BeginVertical();
+			if (tmpAlarm == null) return;
+
+            GUILayout.BeginVertical();
 
 			GUILayout.BeginVertical(GUI.skin.textArea);
 


### PR DESCRIPTION
Revert https://github.com/linuxgurugamer/KerbalAlarmClock/pull/12
Fix https://github.com/linuxgurugamer/KerbalAlarmClock/issues/15 and fix https://github.com/linuxgurugamer/KerbalAlarmClock/issues/10

If had actually bothered to look into the issue in https://github.com/linuxgurugamer/KerbalAlarmClock/issues/10, I would have noticed that the issue was clearly just to do with tmpAlarm being null. Perhaps I got thrown off by siimav's comment and forgot to check. Woops!

New logs:
```
[LOG 22:38:50.491] 6/2/2026 10:38:50 PM,KerbalAlarmClock,API-DeleteAlarm-Deleting:d845d6e3a3a34f479a807128d27ea3b5
[LOG 22:38:50.515] 6/2/2026 10:38:50 PM,KerbalAlarmClock,API-DeleteAlarm-Deleting:56bf0ae9f9c5489ba54b69ad0bde8a59
[LOG 22:38:52.576] 6/2/2026 10:38:52 PM,KerbalAlarmClock,Reducing Warp-Transition
[LOG 22:38:55.675] 6/2/2026 10:38:55 PM,KerbalAlarmClock,Saving Moved Window
[LOG 22:38:55.675] 6/2/2026 10:38:55 PM,KerbalAlarmClock,Triggering Alarm - RP-1: Early Rocketry Complete
[LOG 22:38:55.676] 6/2/2026 10:38:55 PM,KerbalAlarmClock,RP-1: Early Rocketry Complete-Halt Warp
[LOG 22:38:55.677] 6/2/2026 10:38:55 PM,KerbalAlarmClock,Actioning Alarm
[LOG 22:38:55.698] CLAYELADDEDLOGS FillAlarmWindow
[LOG 22:38:55.698] CLAYELADDEDLOGS tmpAlarm == null: False
[LOG 22:38:55.698] CLAYELADDEDLOGS tmpAlarm not null

...

[LOG 22:38:55.952] CLAYELADDEDLOGS FillAlarmWindow
[LOG 22:38:55.952] CLAYELADDEDLOGS tmpAlarm == null: False
[LOG 22:38:55.952] CLAYELADDEDLOGS tmpAlarm not null
[LOG 22:38:55.980] CLAYELADDEDLOGS FillAlarmWindow
[LOG 22:38:55.980] CLAYELADDEDLOGS tmpAlarm == null: False
[LOG 22:38:55.980] CLAYELADDEDLOGS tmpAlarm not null
[LOG 22:38:55.980] 6/2/2026 10:38:55 PM,KerbalAlarmClock,API-DeleteAlarm-Deleting:eb5df1b216984d20b561eae19b0718f1
[LOG 22:38:55.980] CLAYELADDEDLOGS FillAlarmWindow
[LOG 22:38:55.980] CLAYELADDEDLOGS tmpAlarm == null: True
```